### PR TITLE
Improve CI testing

### DIFF
--- a/.github/workflows/llvm-cov.yaml
+++ b/.github/workflows/llvm-cov.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust toolchain with llvm-tools-preview
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@nightly
         with:
           components: llvm-tools-preview
       - name: Checkout private repo
@@ -22,11 +22,21 @@ jobs:
           token: ${{ secrets.AP_COMMON_TOKEN }}
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
+
       - name: Run tests and generate coverage summary (fails if tests fail)
+        if: github.ref == 'refs/heads/main' 
         # This command runs `cargo test` internally.
         # It will print a summary to the console and exit with an error
         # status if any test fails, making the GH Action step fail.
-        run: cargo llvm-cov --all --html
+        run: cargo llvm-cov --all --doctests --html
+
+      - name: Run tests and generate coverage summary (fails if tests fail)
+        if: github.ref != 'refs/heads/main' 
+        # This command runs `cargo test` internally.
+        # It will print a summary to the console and exit with an error
+        # status if any test fails, making the GH Action step fail.
+        run: cargo llvm-cov --all --doctests
+
       # - name: Upload coverage report
       #   uses: actions/upload-artifact@v4
       #   with:
@@ -35,10 +45,12 @@ jobs:
       
       # Prepare the directory for GitHub Pages
       - name: Setup Pages
+        if: github.ref == 'refs/heads/main'
         uses: actions/configure-pages@v5
 
       # Upload the HTML results as the 'github-pages' artifact
       - name: Upload coverage artifact for GitHub Pages
+        if: github.ref == 'refs/heads/main'
         uses: actions/upload-pages-artifact@v3
         with:
           # The path should match the directory where the HTML reports are generated
@@ -46,5 +58,6 @@ jobs:
 
       # Deploy the artifact to GitHub Pages
       - name: Deploy to GitHub Pages
+        if: github.ref == 'refs/heads/main'
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/llvm-cov.yaml
+++ b/.github/workflows/llvm-cov.yaml
@@ -23,8 +23,24 @@ jobs:
         # It will print a summary to the console and exit with an error
         # status if any test fails, making the GH Action step fail.
         run: cargo llvm-cov --all --html
-      - name: Upload coverage report
-        uses: actions/upload-artifact@v4
+      # - name: Upload coverage report
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: llvm-cov-report
+      #     path: target/llvm-cov/html
+      
+      # Prepare the directory for GitHub Pages
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      # Upload the HTML results as the 'github-pages' artifact
+      - name: Upload coverage artifact for GitHub Pages
+        uses: actions/upload-pages-artifact@v3
         with:
-          name: llvm-cov-report
+          # The path should match the directory where the HTML reports are generated
           path: target/llvm-cov/html
+
+      # Deploy the artifact to GitHub Pages
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/llvm-cov.yaml
+++ b/.github/workflows/llvm-cov.yaml
@@ -5,6 +5,10 @@ on: [push, pull_request]
 jobs:
   test-and-verify:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write # Needed for the deploy-pages action
+      id-token: write # Needed for the deploy-pages action
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust toolchain with llvm-tools-preview

--- a/.github/workflows/llvm-cov.yaml
+++ b/.github/workflows/llvm-cov.yaml
@@ -54,7 +54,7 @@ jobs:
     steps:
       # Download the coverage HTML artifact from the test job
       - name: Download coverage HTML artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.1.3
         with:
           name: coverage-html
           path: coverage-html

--- a/.github/workflows/llvm-cov.yaml
+++ b/.github/workflows/llvm-cov.yaml
@@ -23,3 +23,8 @@ jobs:
         # It will print a summary to the console and exit with an error
         # status if any test fails, making the GH Action step fail.
         run: cargo llvm-cov --all
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: llvm-cov-report
+          path: target/llvm-cov/html

--- a/.github/workflows/llvm-cov.yaml
+++ b/.github/workflows/llvm-cov.yaml
@@ -22,7 +22,7 @@ jobs:
         # This command runs `cargo test` internally.
         # It will print a summary to the console and exit with an error
         # status if any test fails, making the GH Action step fail.
-        run: cargo llvm-cov --all
+        run: cargo llvm-cov --all --html
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/llvm-cov.yaml
+++ b/.github/workflows/llvm-cov.yaml
@@ -28,14 +28,14 @@ jobs:
         # This command runs `cargo test` internally.
         # It will print a summary to the console and exit with an error
         # status if any test fails, making the GH Action step fail.
-        run: cargo llvm-cov --all --doctests --html
+        run: cargo +nightly llvm-cov --all --doctests --html
 
       - name: Run tests and generate coverage summary (fails if tests fail)
         if: github.ref != 'refs/heads/main' 
         # This command runs `cargo test` internally.
         # It will print a summary to the console and exit with an error
         # status if any test fails, making the GH Action step fail.
-        run: cargo llvm-cov --all --doctests
+        run: cargo +nightly llvm-cov --all --doctests
 
       # - name: Upload coverage report
       #   uses: actions/upload-artifact@v4

--- a/.github/workflows/llvm-cov.yaml
+++ b/.github/workflows/llvm-cov.yaml
@@ -7,8 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pages: write # Needed for the deploy-pages action
-      id-token: write # Needed for the deploy-pages action
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust toolchain with llvm-tools-preview
@@ -24,40 +22,54 @@ jobs:
         uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Run tests and generate coverage summary (fails if tests fail)
-        if: github.ref == 'refs/heads/main' 
+        if: github.ref == 'refs/heads/main'
         # This command runs `cargo test` internally.
         # It will print a summary to the console and exit with an error
         # status if any test fails, making the GH Action step fail.
         run: cargo +nightly llvm-cov --all --doctests --html
 
       - name: Run tests and generate coverage summary (fails if tests fail)
-        if: github.ref != 'refs/heads/main' 
+        if: github.ref != 'refs/heads/main'
         # This command runs `cargo test` internally.
         # It will print a summary to the console and exit with an error
         # status if any test fails, making the GH Action step fail.
         run: cargo +nightly llvm-cov --all --doctests
 
-      # - name: Upload coverage report
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: llvm-cov-report
-      #     path: target/llvm-cov/html
-      
+      # Upload coverage HTML for the deploy job
+      - name: Upload coverage HTML artifact
+        if: github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-html
+          path: target/llvm-cov/html
+
+  deploy-coverage:
+    needs: test-and-verify
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    steps:
+      # Download the coverage HTML artifact from the test job
+      - name: Download coverage HTML artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-html
+          path: coverage-html
+
       # Prepare the directory for GitHub Pages
       - name: Setup Pages
-        if: github.ref == 'refs/heads/main'
         uses: actions/configure-pages@v5
 
       # Upload the HTML results as the 'github-pages' artifact
       - name: Upload coverage artifact for GitHub Pages
-        if: github.ref == 'refs/heads/main'
         uses: actions/upload-pages-artifact@v3
         with:
-          # The path should match the directory where the HTML reports are generated
-          path: target/llvm-cov/html
+          path: coverage-html
 
       # Deploy the artifact to GitHub Pages
       - name: Deploy to GitHub Pages
-        if: github.ref == 'refs/heads/main'
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
This is just a quick and kinda dirty implementation.

- `llvm-cov` with `--doctests` flag
- GH Pages integration (only if in `main`)